### PR TITLE
2.3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,35 @@
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
 [Oo]bj/
 [Bb]in/
-packages
-*.suo
 *.log
+
+# Visual Studio 2015 cache/options directory
+.vs/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
+# NuGet v3's project.json files produces more ignoreable files
+*.nuget.props
+*.nuget.targets

--- a/Src/Couchbase.ComClient.Test/App.config
+++ b/Src/Couchbase.ComClient.Test/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 		<section name="local" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
@@ -7,7 +7,7 @@
 
 	<local>
 		<servers>
-			<add uri="http://localhost:8091/pools"/>
+			<add uri="http://localhost:8091/pools" />
 		</servers>
 		<buckets>
 			<add name="default" />
@@ -24,4 +24,12 @@
 			</add>
 		</buckets>
 	</local_2>-->
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Src/Couchbase.ComClient.Test/App.config
+++ b/Src/Couchbase.ComClient.Test/App.config
@@ -30,6 +30,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Src/Couchbase.ComClient.Test/BucketWrapperTest.cs
+++ b/Src/Couchbase.ComClient.Test/BucketWrapperTest.cs
@@ -17,6 +17,7 @@
  * ************************************************************/
 
 using System;
+using Couchbase.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Couchbase.ComClient.Test
@@ -57,7 +58,7 @@ namespace Couchbase.ComClient.Test
 		}
 
 		[TestMethod]
-		[ExpectedException(typeof(ArgumentNullException))]
+		[ExpectedException(typeof(MissingKeyException))]
 		public void TestBucketInsert2()
 		{
 			_iBw.Insert(null, "test_value", 60);

--- a/Src/Couchbase.ComClient.Test/Couchbase.ComClient.Test.csproj
+++ b/Src/Couchbase.ComClient.Test/Couchbase.ComClient.Test.csproj
@@ -35,6 +35,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Couchbase.NetClient, Version=2.3.11.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.11\lib\net45\Couchbase.NetClient.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -56,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />

--- a/Src/Couchbase.ComClient.Test/Couchbase.ComClient.Test.csproj
+++ b/Src/Couchbase.ComClient.Test/Couchbase.ComClient.Test.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\CouchbaseNetClient.2.3.11\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/Couchbase.ComClient.Test/packages.config
+++ b/Src/Couchbase.ComClient.Test/packages.config
@@ -3,5 +3,5 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="CouchbaseNetClient" version="2.3.11" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/Src/Couchbase.ComClient.Test/packages.config
+++ b/Src/Couchbase.ComClient.Test/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+</packages>

--- a/Src/Couchbase.ComClient/Couchbase.ComClient.csproj
+++ b/Src/Couchbase.ComClient/Couchbase.ComClient.csproj
@@ -36,25 +36,24 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=3.1.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.3.1.0\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Core.3.1.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.NLog32, Version=3.1.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.NLog32.3.1.0\lib\net40\Common.Logging.NLog32.dll</HintPath>
+    <Reference Include="Common.Logging.NLog32, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.NLog32.3.3.1\lib\net40\Common.Logging.NLog32.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.1.4.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.1.4\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.3.11.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.11\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/Src/Couchbase.ComClient/Couchbase.ComClient.csproj
+++ b/Src/Couchbase.ComClient/Couchbase.ComClient.csproj
@@ -52,8 +52,8 @@
       <HintPath>..\packages\CouchbaseNetClient.2.3.11\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/Src/Couchbase.ComClient/Couchbase.ComClient.csproj
+++ b/Src/Couchbase.ComClient/Couchbase.ComClient.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.4.1\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/Couchbase.ComClient/ObjectUnwrappingTranscoder.cs
+++ b/Src/Couchbase.ComClient/ObjectUnwrappingTranscoder.cs
@@ -23,10 +23,101 @@ using Couchbase.IO.Operations;
 namespace Couchbase.ComClient
 {
 	//use the same implementation as DefaultTranscoder, but base the data type on actual value type rather than T
-	public class ObjectUnwrappingTranscoder : DefaultTranscoder, ITypeTranscoder
+	public class ObjectUnwrappingTranscoder : DefaultTranscoder
 	{
-		//this will override the GetFormat<T> implementation from DefaultTranscoder
-		Flags ITypeTranscoder.GetFormat<T>(T value)
+		public override T Decode<T>(byte[] buffer, int offset, int length, Flags flags, OperationCode opcode)
+		{
+			object value;
+			switch (flags.DataFormat)
+			{
+				case DataFormat.Reserved:
+				case DataFormat.Private:
+					if (typeof(T) == typeof(byte[]))
+					{
+						value = DecodeBinary(buffer, offset, length);
+					}
+					else
+					{
+						value = Decode<T>(buffer, offset, length, opcode);
+					}
+					break;
+
+				case DataFormat.Json:
+					if (typeof(T) == typeof(string))
+					{
+						value = DecodeString(buffer, offset, length);
+					}
+					else
+					{
+						value = DeserializeAsJson<T>(buffer, offset, length);
+					}
+					break;
+
+				case DataFormat.Binary:
+					if (typeof(T) == typeof(byte[]) || typeof(T) == typeof(object))
+					{
+						value = DecodeBinary(buffer, offset, length);
+					}
+					else
+					{
+						string msg = $"The value of T does not match the DataFormat provided: {flags.DataFormat}";
+						throw new ArgumentException(msg);
+					}
+					break;
+
+				case DataFormat.String:
+					if (typeof(T) == typeof(char))
+					{
+						value = DecodeChar(buffer, offset, length);
+					}
+					else
+					{
+						value = DecodeString(buffer, offset, length);
+					}
+					break;
+
+				default:
+					value = DecodeString(buffer, offset, length);
+					break;
+			}
+
+			return (T)value;
+		}
+
+		public override byte[] Encode<T>(T value, Flags flags, OperationCode opcode)
+		{
+			byte[] bytes;
+			switch (flags.DataFormat)
+			{
+				case DataFormat.Reserved:
+				case DataFormat.Private:
+				case DataFormat.String:
+					bytes = Encode(value, flags.TypeCode, opcode);
+					break;
+
+				case DataFormat.Json:
+					bytes = SerializeAsJson(value);
+					break;
+
+				case DataFormat.Binary:
+					if (value.GetType() == typeof(byte[]))
+					{
+						bytes = value as byte[];
+					}
+					else
+					{
+						string msg = $"The value of T does not match the DataFormat provided: {flags.DataFormat}";
+						throw new ArgumentException(msg);
+					}
+					break;
+
+				default:
+					throw new ArgumentOutOfRangeException(nameof(flags), "Flag DataFormat is not supported!");
+			}
+			return bytes;
+		}
+
+		public override Flags GetFormat<T>(T value)
 		{
 			var dataFormat = DataFormat.Json;
 			var typeCode = TypeCode.Object;
@@ -62,7 +153,7 @@ namespace Couchbase.ComClient
 						dataFormat = DataFormat.String;
 						break;
 					default:
-						throw new ArgumentOutOfRangeException();
+						throw new ArgumentOutOfRangeException(nameof(value), "TypeCode is not supported!");
 				}
 			}
 			return new Flags() { Compression = Compression.None, DataFormat = dataFormat, TypeCode = typeCode };

--- a/Src/Couchbase.ComClient/packages.config
+++ b/Src/Couchbase.ComClient/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="3.1.0" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="3.1.0" targetFramework="net45" />
-  <package id="Common.Logging.NLog32" version="3.1.0" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.1.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.NLog32" version="3.3.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NLog" version="3.2.0.0" targetFramework="net45" />
 </packages>

--- a/Src/Couchbase.ComClient/packages.config
+++ b/Src/Couchbase.ComClient/packages.config
@@ -4,6 +4,6 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.NLog32" version="3.3.1" targetFramework="net45" />
   <package id="CouchbaseNetClient" version="2.3.11" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NLog" version="3.2.0.0" targetFramework="net45" />
 </packages>

--- a/Src/Couchbase.ComClient/packages.config
+++ b/Src/Couchbase.ComClient/packages.config
@@ -5,5 +5,5 @@
   <package id="Common.Logging.NLog32" version="3.3.1" targetFramework="net45" />
   <package id="CouchbaseNetClient" version="2.3.11" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
+  <package id="NLog" version="4.4.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Updated Couchbase SDK to 2.3.11
- Updated Newtonsoft.Json to 9.0.1
- Updated NLog to 4.4.1
- Enhanced ObjectUnwrappingTranscoder to correctly handle binary data in get operations
- Added standard .NET .gitignore and .gitattributes
